### PR TITLE
Improve SEO metadata for portfolio homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,33 +5,35 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Thang Ly</title>
+    <link rel="canonical" href="https://thangly.vercel.app/" />
+    <meta name="robots" content="index, follow" />
+    <meta name="author" content="Thang Ly" />
     <meta
       name="description"
-      content="Discover Thang Ly's personal website, highlighting his programming expertise, project portfolio, and proficiency in web development."
+      content="Explore Thang Ly's front-end developer portfolio, showcasing web applications, UI engineering skills, and a passion for creating performant digital experiences."
     />
     <meta
-      property="description"
-      content="Discover Thang Ly's personal website, highlighting his programming expertise, project portfolio, and proficiency in web development."
-    />
-    <meta property="twitter:image" content="https://i.ibb.co/r8KfMJG/thangly98-twitter-thumbnail-small.png" />
-    <meta property="twitter:card" content="app" />
-    <meta property="twitter:title" content="Thang Ly | Front-End Developer Portfolio" />
-    <meta
-      property="twitter:description"
-      content="Discover Thang Ly's personal website, highlighting his programming expertise, project portfolio, and proficiency in web development."
+      name="keywords"
+      content="Thang Ly, Finn, front-end developer, web developer portfolio, UI engineer, React projects, TypeScript, Tailwind CSS"
     />
     <meta property="og:title" content="Thang Ly | Front-End Developer Portfolio" />
     <meta property="og:type" content="profile" />
     <meta property="og:url" content="https://thangly.vercel.app/" />
     <meta property="og:image" content="https://i.ibb.co/JRyypdDf/thangly98-web-thumbnail-small.png" />
+    <meta property="og:image:alt" content="Screenshot of Thang Ly's portfolio website" />
     <meta property="og:site_name" content="Thang Ly" />
+    <meta property="og:locale" content="en_US" />
     <meta
       property="og:description"
-      content="Discover Thang Ly's personal website, highlighting his programming expertise, project portfolio, and proficiency in web development."
+      content="Explore Thang Ly's front-end developer portfolio, showcasing web applications, UI engineering skills, and a passion for creating performant digital experiences."
     />
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:title" content="Thang Ly | Front-End Developer Portfolio" />
+    <meta property="twitter:image" content="https://i.ibb.co/r8KfMJG/thangly98-twitter-thumbnail-small.png" />
+    <meta property="twitter:image:alt" content="Screenshot of Thang Ly's portfolio website" />
     <meta
-      name="keywords"
-      content="thangly, thang ly, finn, Front-end developer, Developer portfolio, Personal website, Web development, Programming, Front-end developer personal website, Portfolio website for front-end developers, Web developer personal online profile, Programming skills showcase, Front-end engineer personal branding, Showcasing front-end development expertise, Personal web page for front-end programmers, Design and development of a front-end developer's website, Online portfolio for a front-end coding professional, Personal brand building for a front-end software engineer"
+      property="twitter:description"
+      content="Explore Thang Ly's front-end developer portfolio, showcasing web applications, UI engineering skills, and a passion for creating performant digital experiences."
     />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
## Summary
- add canonical link, robots, and author meta tags to improve SEO
- refine Open Graph and Twitter metadata with alt text and locale
- streamline description and keyword content for clearer messaging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4bf329bc0832ba4bf411c20040281