### PR TITLE
Fix PR build workflow to use Yarn

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -12,22 +12,26 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # Thiết lập môi trường Node.js (hoặc ngôn ngữ khác, tùy thuộc vào dự án của bạn)
+      # Thiết lập môi trường Node.js
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 18
+          cache: yarn
 
-      # Cài đặt dependencies
+      - name: Enable Corepack
+        run: corepack enable
+
+      # Cài đặt dependencies bằng Yarn để đồng bộ với dự án
       - name: Install dependencies
-        run: npm install
+        run: yarn install --immutable
 
       # Build dự án
       - name: Build
-        run: npm run build
+        run: yarn build
 
-      # Chạy các test
+      # Chạy các test (ở chế độ non-watch cho môi trường CI)
       - name: Run tests
-        run: npm test
+        run: yarn test --run


### PR DESCRIPTION
## Summary
- update the PR build workflow to use the latest checkout/setup-node actions with Yarn caching
- enable Corepack and install dependencies with Yarn so CI aligns with the repository setup
- run build and test steps via Yarn with a CI-friendly Vitest command

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e4c3a2f0fc832bb6c1c1b7424f0197