### PR TITLE
Gate merges behind successful PR build

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -12,22 +12,26 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # Thiết lập môi trường Node.js (hoặc ngôn ngữ khác, tùy thuộc vào dự án của bạn)
+      # Thiết lập môi trường Node.js
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: 18
+          cache: yarn
 
-      # Cài đặt dependencies
+      - name: Enable Corepack
+        run: corepack enable
+
+      # Cài đặt dependencies bằng Yarn để đồng bộ với dự án
       - name: Install dependencies
-        run: npm install
+        run: yarn install --immutable
 
       # Build dự án
       - name: Build
-        run: npm run build
+        run: yarn build
 
-      # Chạy các test
+      # Chạy các test (ở chế độ non-watch cho môi trường CI)
       - name: Run tests
-        run: npm test
+        run: yarn test --run

--- a/.github/workflows/pr-merge-gate.yml
+++ b/.github/workflows/pr-merge-gate.yml
@@ -1,0 +1,70 @@
+name: Enforce PR Ready State
+
+on:
+  workflow_run:
+    workflows:
+      - PR Build and Test
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  toggle-pr-readiness:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    steps:
+      - name: Toggle draft state based on build status
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const conclusion = context.payload.workflow_run.conclusion;
+            const prs = context.payload.workflow_run.pull_requests || [];
+
+            if (!prs.length) {
+              core.info('No associated pull requests found.');
+              return;
+            }
+
+            for (const pr of prs) {
+              const prNumber = pr.number;
+              const nodeId = pr.node_id;
+
+              if (!nodeId) {
+                core.warning(`PR #${prNumber} is missing a node id; skipping.`);
+                continue;
+              }
+
+              if (conclusion === 'success') {
+                try {
+                  await github.graphql(
+                    `mutation ($id: ID!) {
+                      markPullRequestReadyForReview(input: {pullRequestId: $id}) {
+                        pullRequest { number }
+                      }
+                    }`,
+                    { id: nodeId }
+                  );
+                  core.info(`Marked PR #${prNumber} as ready for review.`);
+                } catch (error) {
+                  core.warning(`Could not mark PR #${prNumber} as ready: ${error.message}`);
+                }
+              } else {
+                try {
+                  await github.graphql(
+                    `mutation ($id: ID!) {
+                      convertPullRequestToDraft(input: {pullRequestId: $id}) {
+                        pullRequest { number }
+                      }
+                    }`,
+                    { id: nodeId }
+                  );
+                  core.info(`Converted PR #${prNumber} to draft due to ${conclusion} status.`);
+                } catch (error) {
+                  core.warning(`Could not convert PR #${prNumber} to draft: ${error.message}`);
+                }
+              }
+            }


### PR DESCRIPTION
## Summary
- add a workflow_run automation that tracks the PR Build and Test workflow
- automatically mark pull requests ready for review only after the build succeeds
- convert failing pull requests back to draft so they cannot be merged while checks are red

## Testing
- not run (workflow change only)

------
https://chatgpt.com/codex/tasks/task_e_68e4c3a2f0fc832bb6c1c1b7424f0197